### PR TITLE
fix(check-version): update cargo query parameters in check_version.py

### DIFF
--- a/script/check_version.py
+++ b/script/check_version.py
@@ -10,11 +10,10 @@ from urllib.parse import urlencode
 
 params = {
     "action": "cargoquery",
-    "tables": "char_obtain,chara",
-    "fields": "char_obtain._pageName=name",
+    "tables": "chara",
+    "fields": "chara._pageName=name",
     "where": 'chara.rarity="5"',
-    "join_on": "char_obtain._pageName=chara._pageName",
-    "order_by": "char_obtain.cnOnlineTime desc",
+    "order_by": "chara.charIndex desc",
     "limit": 1,
     "format": "json",
     "formatversion": 2,


### PR DESCRIPTION
<img width="1046" height="259" alt="图片" src="https://github.com/user-attachments/assets/032531c4-d12a-4b7c-92d9-59d312ed5653" />

PRTS的[char_obtain](https://prts.wiki/w/%E7%89%B9%E6%AE%8A:CargoTables/char_obtain)表似乎有误，电弧的上线时间是`2025年7月8日 16:00`，和司霆惊蛰一致。

在 8482fac14efe389d3b914f5b97d50e5b8a6a4e51 中，上面的问题导致了一次错误的全量更新。已经在 3c978d0f9b1a5569c5b3b92bb91711765cef6c9f 中回退。

修改为使用chara.charIndex排序，避免出错。